### PR TITLE
Updated Vulkan/VkSceneGraph link to the vsg-dev project github account.

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ drm/kms.
 *  [vRt](https://github.com/world8th/vRt) - Vulkan API (>=1.1) based unified ray tracing library. [LGPL-3.0]
 *  [rostkatze](https://github.com/msiglreith/rostkatze) - C++ implementation of Vulkan sitting on D3D12 🐈[Apache License 2.0]
 *  [Fossilize](https://github.com/Themaister/Fossilize) - serialization format for various persistent Vulkan object types. [MIT]
-*  [VulkanSceneGraph](https://github.com/openscenegraph/VulkanSceneGraph) - next-gen OpenSceneGraph.
+*  [Vulkan/VkSceneGraph](https://github.com/vsg-dev) - Vulkan/C++17 scene graph project, successor to [OpenSceneGraph](http://www.openscenegraph.org).
 *  [clspv](https://github.com/google/clspv) - prototype compiler for a subset of OpenCL C to Vulkan compute shaders. [Apache License 2.0]
 *  [Pumex](https://github.com/pumexx/pumex) - cross-platform Vulkan renderer implementing frame graph and simple scene graph. Able to render on many surfaces at once [MIT]
 *  [VUDA](https://github.com/jgbit/vuda) - header-only lib that provides a CUDA Runtime API interface. [MIT]


### PR DESCRIPTION
The VulkanSceneGraph project now has it's own dedicated vsg-dev github account so I've updated the links.  Thanks.