### PR TITLE
Add Ash

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ drm/kms.
 *  [small3d](https://www.gamedev.net/projects/515-small3d/), Tiny Vulkan based C++ cross-platform game development framework [BSD 3-clause]
 
 ## Bindings
+*  [ash](https://github.com/MaikKlein/ash) - Vulkan bindings for Rust. [MIT]
 *  [libvulkan.lua](https://github.com/CapsAdmin/ffibuild/blob/master/vulkan/vulkan.lua) - Lua bindings for Vulkan.
 *  [dvulkan](https://github.com/ColonelThirtyTwo/dvulkan) - Auto-generated D bindings for Vulkan.
 *  [ErupteD](https://github.com/ParticlePeter/ErupteD) - Another Auto-generated D bindings for Vulkan.


### PR DESCRIPTION
Ash is a Vulkan bindings library for Rust with following properties:
- A true Vulkan API without compromises
- Convenience features without limiting functionality
- Additional type safety
- Device local function pointer loading
- No validation, everything is unsafe
- Generated from vk.xml
- Support for Vulkan 1.1