### PR TITLE
Add Silk.NET to bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ drm/kms.
 *  [dvulkan](https://github.com/ColonelThirtyTwo/dvulkan) - Auto-generated D bindings for Vulkan.
 *  [ErupteD](https://github.com/ParticlePeter/ErupteD) - Another Auto-generated D bindings for Vulkan.
 *  [flextGL](https://github.com/mosra/flextgl) - Minimal Vulkan header/loader generator and [the blog post](http://blog.magnum.graphics/hacking/simple-efficient-vulkan-loading-with-flextgl/) about it.
+*  [Silk.NET](https://github.com/dotnet/Silk.NET) - C# bindings for Vulkan and others. [MIT]
 *  [vulkan](https://github.com/expipiplus1/vulkan) - Haskell bindings for Vulkan and Vulkan Memory Allocator [BSD-3-Clause]
 *  [nvk](https://github.com/maierfelix/nvk) - JavaScript bindings for Vulkan. [MIT]
 *  [racket-vulkan](https://github.com/zyrolasting/racket-vulkan) - Racket bindings for Vulkan with [detailed implementation notes](https://sagegerard.com/racket-vulkan-notes-index.html). [MIT]


### PR DESCRIPTION
Hello :wave: just wanted to add Silk.NET to the bindings section, it's very well supported if I may say so myself, and has joined the .NET Foundation recently hopefully keeping it that way for a long time.