### PR TITLE
Add Vortice.Vulkan to bindings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ drm/kms.
 *  [PasVulkan](https://github.com/BeRo1985/pasvulkan) - Vulkan bindings plus high-level wrapper library for Object Pascal [Zlib]
 *  [vulkan-zig](https://github.com/Snektron/vulkan-zig) - Vulkan binding generator for Zig [MIT]
 *  [VK²](https://github.com/kotlin-graphics/vkk), Kotlin Wrapper for Vulkan: code expressiveness and safety meet graphic power [Apache License 2.0]
+*  [Vortice.Vulkan](https://github.com/amerkoleci/Vortice.Vulkan) - .NET Standard 2.0 and .NET5 C# bindings [MIT]
 
 
 ## Tools


### PR DESCRIPTION
Hello 👋 just wanted to add Vortice.Vulkan to the bindings section, it supported .NET Standard 2.0 and .NET5.0 with high performance and cross platform C# support. It is used by Stride game engine as well.