### PR TITLE
Updated information about Falcor

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ drm/kms.
    *  [Screen 13](https://github.com/attackgoat/screen-13) - An easy-to-use Vulkan render graph for Rust. [MIT]
 
 * Frameworks, Engines, Higher Level Rendering
-   *  [Falcor](https://github.com/NVIDIAGameWorks/Falcor) - Real-time rendering framework from NVIDIA, supporting DX12 and Vulkan. [BSD 3-clause]
+   *  [Falcor](https://github.com/NVIDIAGameWorks/Falcor) - Real-time rendering framework from NVIDIA, supporting mainly DX12, with experimental Vulkan support. [BSD 3-clause]
    *  [The-Forge](https://github.com/ConfettiFX/The-Forge) - DirectX 12, Vulkan, macOS Metal 2 rendering framework. [Apache License 2.0]
    *  [Diligent Engine](https://github.com/DiligentGraphics/DiligentEngine) - a modern cross-platform low-level graphics library that supports OpenGL/GLES, Direct3D11/12 and Vulkan. [Apache License 2.0]
    *  [DemoFramework](https://github.com/NXPmicro/gtec-demo-framework) - NXP GTEC C++11 cross-platform demo framework including lots of samples for Vulkan, OpenGL ES, OpenVX, OpenCL, OpenVG and OpenCV. [[BSD-3-clause](https://github.com/NXPmicro/gtec-demo-framework/blob/master/License.md)]


### PR DESCRIPTION
Not sure about the Vulkan support in the latest versions of Falcor, or if there is still any support for it. The beginning of [Falcor's README.md](https://github.com/NVIDIAGameWorks/Falcor) not even mentions Vulkan anymore:

> Falcor is a real-time rendering framework supporting DirectX 12. It aims to improve productivity of research and prototype projects.

but further down, some mentions of Vulkan can be found:

> Slang GFX backend using Vulkan (experimental)

Looks like Vulkan support has stopped some time in 2019. 