### PR TITLE
Add "Papers" section, and add our education paper "The Road to Vulkan: Teaching Modern Low-Level APIs in Introductory Graphics Courses"

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,8 @@ drm/kms.
 
 ## Papers
 *  [The Road to Vulkan: Teaching Modern Low-Level APIs in Introductory Graphics Courses](https://www.cg.tuwien.ac.at/research/publications/2022/unterguggenberger-2022-vulkan) by **Johannes Unterguggenberger**, **Bernhard Kerbl**, and **Michael Wimmer**, Eurographics 2022 - Education Papers
-    * Pre-recorded presentation on [YouTube](https://youtu.be/ZG0ct4V6c0k).
+    *  Direct link to the [paper](https://www.cg.tuwien.ac.at/research/publications/2022/unterguggenberger-2022-vulkan/unterguggenberger-2022-vulkan-paper.pdf).
+    *  Pre-recorded presentation on [YouTube](https://youtu.be/ZG0ct4V6c0k).
 
 ## Khronos
 *  Specification

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A curated list of awesome Vulkan libraries, debuggers and resources. Inspired by
 * **[Bindings](#bindings)**
 * **[Tools](#tools)**
 * **[Books](#books)**
+* **[Papers](#papers)**
 * **[Khronos](#khronos)**
 * **[Community](#community)**
 
@@ -287,6 +288,10 @@ drm/kms.
 * [Vulkan Cookbook](https://www.amazon.com/Vulkan-Cookbook-Pawel-Lapinski/dp/1786468158)- by **Pawel Lapinski** - Explores a wide range of graphics programming and GPU compute methods to make the best use of the Vulkan API.
   * [Book's Examples](https://github.com/PacktPublishing/Vulkan-Cookbook)
 * [Vulkan Programming Guide](https://www.amazon.com/Vulkan-Programming-Guide-Official-Learning/dp/0134464540) - by **Graham Sellers** and **John Kessenich** - Introduces powerful 3D development techniques for many fields.
+
+## Papers
+*  [The Road to Vulkan: Teaching Modern Low-Level APIs in Introductory Graphics Courses](https://www.cg.tuwien.ac.at/research/publications/2022/unterguggenberger-2022-vulkan) by **Johannes Unterguggenberger**, **Bernhard Kerbl**, and **Michael Wimmer**, Eurographics 2022 - Education Papers
+    * Pre-recorded presentation on [YouTube](https://youtu.be/ZG0ct4V6c0k).
 
 ## Khronos
 *  Specification


### PR DESCRIPTION
The paper is about teaching Vulkan in university education, i.e., how to teach Vulkan right from the beginning as the first graphics API. We describe our approach how we successfully made the transition from OpenGL to Vulkan in introductory grahpics courses.

Wasn't sure if a new section was appropriate, but it doesn't really fit well into the other sections. Hope, this is fine.